### PR TITLE
Updates for zig master (code broken with zig 7f03cfe161a2f7b5abbd00ab1ea29ddd6190d435 on 2021-09-01)

### DIFF
--- a/gyro.zzz
+++ b/gyro.zzz
@@ -16,13 +16,13 @@ deps:
   iguanaTLS:
     src:
       github:
-        user: alexnask
+        user: nektro
         repo: iguanaTLS
-        ref: 0d39a361639ad5469f8e4dcdaea35446bbe54b48
+        ref: 953ad821fae6c920fb82399493663668cd91bde7
   network:
     root: network.zig
     src:
       github:
         user: MasterQ32
         repo: zig-network
-        ref: b9c91769d8ebd626c8e45b2abb05cbc28ccc50da
+        ref: 15b88658809cac9022ec7d59449b0cd3ebfd0361

--- a/src/socket.zig
+++ b/src/socket.zig
@@ -56,7 +56,7 @@ fn SocketWrapper(comptime Engine: type) type {
 
         fn connectToAddress(_: *Allocator, address: Address) !Engine.Socket {
             switch (address.any.family) {
-                std.os.AF_INET => {
+                std.os.AF.INET => {
                     const bytes = @ptrCast(*const [4]u8, &address.in.sa.addr);
                     var ipv4 = network.Address{ .ipv4 = network.Address.IPv4.init(bytes[0], bytes[1], bytes[2], bytes[3]) };
                     var port = address.getPort();


### PR DESCRIPTION
As of zig [7f03cfe](https://github.com/ziglang/zig/commit/7f03cfe161a2f7b5abbd00ab1ea29ddd6190d435), AF_INET has been removed and replaced with AF that contains INET/INET6/etc.

This PR allows use after that commit. Note that to do this, I needed to used a fork of iguanaTLS. There is an open PR on iguanaTLS that once merged will allow requestz to move back to the main repo.